### PR TITLE
Improve dev setup script for Flutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .packages
 .pub/
 build/
+flutter-sdk/
 # Node
 functions/node_modules/
 print-daemon/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Operation Summer
 
 Initial scaffolding auto-generated. Run `scripts/dev_setup.sh` after cloning.
+The setup script installs Flutter automatically when needed.
 
 A family management app to assist with schedules, chores, entertainment, and education.

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 set -e
+if ! command -v flutter >/dev/null 2>&1; then
+    echo "Flutter not found – installing locally..."
+    git clone https://github.com/flutter/flutter.git -b stable flutter-sdk
+    export PATH="$PWD/flutter-sdk/bin:$PATH"
+fi
 flutter pub get -C app
 npm ci -C functions
 npm ci -C print-daemon


### PR DESCRIPTION
## Summary
- install Flutter locally in `scripts/dev_setup.sh` when it's missing
- ignore the local `flutter-sdk` directory in git
- clarify in README that the setup script will install Flutter automatically

## Testing
- `scripts/dev_setup.sh` *(fails: unable to access 'https://github.com/flutter/flutter.git' - couldn't connect to server)*
- `npm test -C functions` *(fails: Missing script: "test")*
- `flutter test -C app` *(fails: flutter: command not found)*